### PR TITLE
output json for debug & view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+rule-set
+*.db

--- a/sing-geoip/main.go
+++ b/sing-geoip/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"io"
 	"net"
 	"net/http"
@@ -234,6 +235,22 @@ func release(source string, destination string, output string, ruleSetOutput str
 			return err
 		}
 		err = srs.Write(outputRuleSet, plainRuleSet)
+		if err != nil {
+			outputRuleSet.Close()
+			return err
+		}
+		outputRuleSet.Close()
+
+		srsPath, _ = filepath.Abs(filepath.Join(ruleSetOutput, "geoip-"+countryCode+".json"))
+		os.Stderr.WriteString("write " + srsPath + "\n")
+		outputRuleSet, err = os.Create(srsPath)
+		if err != nil {
+			return err
+		}
+		je := json.NewEncoder(outputRuleSet)
+		je.SetEscapeHTML(false)
+		je.SetIndent("", "    ")
+		err = je.Encode(plainRuleSet)
 		if err != nil {
 			outputRuleSet.Close()
 			return err

--- a/sing-geosite/main.go
+++ b/sing-geosite/main.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"io"
 	"net/http"
 	"os"
@@ -233,6 +234,22 @@ func generate(release *github.RepositoryRelease, output string, cnOutput string,
 			return err
 		}
 		err = srs.Write(outputRuleSet, plainRuleSet)
+		if err != nil {
+			outputRuleSet.Close()
+			return err
+		}
+		outputRuleSet.Close()
+
+		srsPath, _ = filepath.Abs(filepath.Join(ruleSetOutput, "geosite-"+code+".json"))
+		os.Stderr.WriteString("write " + srsPath + "\n")
+		outputRuleSet, err = os.Create(srsPath)
+		if err != nil {
+			return err
+		}
+		je := json.NewEncoder(outputRuleSet)
+		je.SetEscapeHTML(false)
+		je.SetIndent("", "    ")
+		err = je.Encode(plainRuleSet)
 		if err != nil {
 			outputRuleSet.Close()
 			return err


### PR DESCRIPTION
#6 的 PR

效果见 <https://github.com/117503445/sing-box-rules/tree/rule-set-geosite>

我认为添加 JSON 输出确实挺方便的，在调试 sing-box 规则时能清楚知道 srs 文件内的详细规则